### PR TITLE
fix: fix play button not working when the bar is open

### DIFF
--- a/app/useCollectionOperations.js
+++ b/app/useCollectionOperations.js
@@ -191,7 +191,6 @@ export function useCollectionOperations({
     };
 
     const _handleOpenTabs = async () => {
-        if (isExpanded) return;
         if (await _isAutoUpdate()) {
             await _handleFocusWindow();
             return;


### PR DESCRIPTION
This fixes the issue: "Collection won't open #85".
I found a similar problem reported by the user in issue #85. When the bar was open, the play button wouldn’t work.
I have removed the return statement that was triggered when the tab was open.