### PR TITLE
fix(ci): drop stale detect-libc descriptor from server/yarn.lock

### DIFF
--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -924,7 +924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.0, detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2::__archiveUrl=https%3A%2F%2Fregistry.yarnpkg.com%2Fdetect-libc%2F-%2Fdetect-libc-2.1.2.tgz"
   checksum: 10/b736c8d97d5d46164c0d1bed53eb4e6a3b1d8530d460211e2d52f1c552875e706c58a5376854e4e54f8b828c9cada58c855288c968522eb93ac7696d65970766


### PR DESCRIPTION
## Problem
`yarn install --immutable` fails in CI (e.g. **Deploy Entitlement Worker**) with YN0028 "The lockfile would have been modified by this install": the `server/yarn.lock` entry `detect-libc@npm:^2.0.0, detect-libc@npm:^2.1.2` collapses to `detect-libc@npm:^2.1.2` because no dependency requests `^2.0.0` anymore.

## Fix
One-line lockfile metadata change in `server/yarn.lock` — the merged descriptor now lists only `^2.1.2`. The resolved version (2.1.2), archive URL, and checksum are unchanged. The root `yarn.lock` has no detect-libc entry and passes `yarn install --immutable` cleanly as-is.

## Verification
- `yarn install --immutable` at repo root: passes
- `server/` install no longer emits YN0028 (local fetch step can't complete on this machine's network, but resolution/lockfile validation — the failing CI step — passes)
- `yarn test`: 1850/1850 pass
- `yarn lint`: clean
- No Wix-internal registry hostnames in either lockfile (all URLs are registry.yarnpkg.com / registry.npmjs.org)

## ⚠️ Note for merging
Merging to `main` triggers the store publish CI (Chrome Web Store + Edge Add-ons). Merge when you intend the current `main` to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)