### PR TITLE
fix: pin @dnd-kit/utilities to public 3.2.2 (CI yarn install failure)

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,5 +155,8 @@
     "webpack-cli": "^6.0.1",
     "webpack-extension-manifest-plugin": "^0.8.0"
   },
+  "resolutions": {
+    "@dnd-kit/utilities": "3.2.2"
+  },
   "packageManager": "yarn@4.12.0"
 }

--- a/tests/pricingTemplate.test.js
+++ b/tests/pricingTemplate.test.js
@@ -1,4 +1,4 @@
-const { mkdtempSync, readFileSync, rmSync } = require('fs');
+const { existsSync, mkdtempSync, readFileSync, rmSync } = require('fs');
 const { tmpdir } = require('os');
 const { join } = require('path');
 const { spawnSync } = require('child_process');
@@ -60,7 +60,10 @@ describe('Wix pricing page template', () => {
 
     test('builds a Wix snippet within the 15,000 character limit', () => {
         const canonicalOutputPath = join(projectRoot, 'site', 'pricing', 'pricing.html');
-        const canonicalOutputBefore = readFileSync(canonicalOutputPath, 'utf8');
+        // pricing.html is gitignored build output; it exists locally but not on CI
+        const canonicalOutputBefore = existsSync(canonicalOutputPath)
+            ? readFileSync(canonicalOutputPath, 'utf8')
+            : null;
         const tempDirectory = mkdtempSync(join(tmpdir(), 'tabox-pricing-'));
         const tempOutputPath = join(tempDirectory, 'pricing.html');
 
@@ -84,7 +87,11 @@ describe('Wix pricing page template', () => {
             expect(result.status).toBe(0);
             const built = readFileSync(tempOutputPath, 'utf8');
             expect([...built].length).toBeLessThanOrEqual(15000);
-            expect(readFileSync(canonicalOutputPath, 'utf8')).toBe(canonicalOutputBefore);
+            if (canonicalOutputBefore === null) {
+                expect(existsSync(canonicalOutputPath)).toBe(false);
+            } else {
+                expect(readFileSync(canonicalOutputPath, 'utf8')).toBe(canonicalOutputBefore);
+            }
         } finally {
             rmSync(tempDirectory, { recursive: true, force: true });
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,14 +1662,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dnd-kit/utilities@npm:^3.2.2":
-  version: 3.3.0
-  resolution: "@dnd-kit/utilities@npm:3.3.0"
+"@dnd-kit/utilities@npm:3.2.2":
+  version: 3.2.2
+  resolution: "@dnd-kit/utilities@npm:3.2.2"
   dependencies:
     tslib: "npm:^2.0.0"
   peerDependencies:
     react: ">=16.8.0"
-  checksum: 10/31fa6f4c54587299d3b61346e2bb5f3c709a49724e8ea2748b7b80639e42d04e4b6d46c206bf257b6b5126011bd78bf5774906485ad05001d08e2a5842d9aa18
+  checksum: 10/6cfe46a5fcdaced943982e7ae66b08b89235493e106eb5bc833737c25905e13375c6ecc3aa0c357d136cb21dae3966213dba063f19b7a60b1235a29a7b05ff84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem
GitHub Actions fails at `yarn install` on main:
`@dnd-kit/utilities@npm:3.3.0: Registry failed to return reference "3.3.0"`

3.3.0 only exists on the Wix internal npm registry (a wix-private fork; public npm latest is 3.2.2). package.json requests `^3.2.2`, but the dev machine resolves through the Wix registry, so yarn.lock locked the internal-only 3.3.0.

## Fix
- Added `"resolutions": {"@dnd-kit/utilities": "3.2.2"}` to package.json and regenerated the lockfile entry.
- Lockfile entry is the canonical `@dnd-kit/utilities@npm:3.2.2` form with no `__archiveUrl` and no Wix hostnames anywhere in yarn.lock.
- Tarball verified genuine: sha512 matches npm `dist.integrity`, sha1 matches `dist.shasum`.
- Scanned **all 916 lockfile entries** against public npm (via jsDelivr version API) — no other internal-only versions exist; this was the only stray.

## Verification
- `yarn install --immutable` passes
- `yarn test`: 251 suites / 1850 tests pass
- `yarn lint`: clean
- `yarn prod`: compiles successfully

## ⚠️ Release note
Merging to main triggers the store-publish CI (Chrome Web Store + Edge Add-ons). If deploys were already done manually, cancel the publish runs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)